### PR TITLE
Added tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+REPORTER = nyan
+TESTS = tests/*.js
+
+test:
+	@NODE_ENV=test ./node_modules/.bin/mocha --harmony-generators \
+	--reporter $(REPORTER) \
+	$(TESTS) \
+
+.PHONY: test

--- a/app.js
+++ b/app.js
@@ -9,6 +9,10 @@ var passport = require('koa-passport');
 var session = require('koa-generic-session');
 
 var app = koa();
+
+// This is for use in tests.
+module.exports = app;
+
 app.use(bodyParser());
 app.use(serve('./assets'));
 

--- a/package.json
+++ b/package.json
@@ -21,10 +21,16 @@
     "xml2js": "^0.4.4",
     "nodemon": "^1.3.1"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "mocha": "^2.1.0",
+    "chai": "^1.10.0",
+    "supertest": "^0.15.0",
+    "co-supertest": "0.0.7",
+    "co-mocha": "^1.1.0"
+  },
   "scripts": {
     "start": "./node_modules/.bin/nodemon --harmony-generators app.js | ./node_modules/.bin/bunyan",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "make test"
   },
   "repository": {
     "type": "git",

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,11 @@
+chai = require('chai');
+
+app  = require('../app');
+
+api = require('co-supertest').agent(app.listen());
+
+describe("Test test", function() {
+  it("should get a 200 from the index page", function*() {
+    yield api.get('/').expect(200).end();
+  });
+});


### PR DESCRIPTION
This adds tests now when using `npm test`. It utilizes [Mocha](http://mochajs.org/), but a variant that allows developers to use generators inside of tests. I've included supertest (and it's co version that includes generator functionality), since that tends to be pretty helpful when testing APIs.

I usually use [Chai](http://chaijs.com/) to add expect/should functionality, so I also included that. There's probably a co plugin that would help keep generators running.
