### PR TITLE
Redis passport session storage. [Fixes #5]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A hosted version of the software can be found here: [Bloodhound.TV](http://blood
 ## Installation
 - Make sure the latest version of [node](http://nodejs.org/) is installed
 - Install [n](https://www.npmjs.com/package/n)
+- Make sure to install and have [Redis](http://redis.io/) running.
 
 ```
 sudo npm install -g n

--- a/README.md
+++ b/README.md
@@ -27,14 +27,6 @@ cd bloodhound
 npm install
 ```
 - Download and run [CouchDB](http://couchdb.apache.org/)
-- Open the CouchDB web admin panel: [Futon](http://127.0.0.1:5984/)
-- Create the following databases:
-    - ```users```
-    - ```index```
-    - ```searches```
-    - ```shows```
-    - ```listings```
-
 - Rename ```config.json.example``` file to ```config.json``` and enter all applicable keys where you see ```XXX```
 - Run Bloodhound
 

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ var bodyParser = require('koa-bodyparser');
 require('./models/auth');
 var passport = require('koa-passport');
 var session = require('koa-generic-session');
+var redisStorage = require('koa-redis');
 
 var app = koa();
 
@@ -26,7 +27,10 @@ app.use(hbs.middleware({
 var config = require('./config.json');
 app.keys = config.app.data.session_keys;
 
-app.use(session());
+app.use(session({
+  cookie: {maxAge: 1000 * 60 * 5},
+  store : redisStorage()
+}));
 app.use(passport.initialize());
 app.use(passport.session());
 app.use(router(app));

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "passport-twitter": "^1.0.2",
     "request": "^2.51.0",
     "xml2js": "^0.4.4",
-    "nodemon": "^1.3.1"
+    "nodemon": "^1.3.1",
+    "koa-redis": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "^2.1.0",


### PR DESCRIPTION
Redis is now used to persist passport sessions. Just make sure it's running. It should just use the redis default port.

This fixes #5 
